### PR TITLE
Put desired Java version in front of PATH

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ name = "Penpot"
 description.en = "Design and prototyping platform"
 description.fr = "Plateforme de conception et de prototypage"
 
-version = "1.19.3~ynh2"
+version = "1.19.3~ynh3"
 
 maintainers = ["orhtej2"]
 

--- a/scripts/install
+++ b/scripts/install
@@ -44,7 +44,7 @@ ynh_secure_remove --file=$tmp_dir
 
 ynh_setup_source --dest_dir="$install_dir/babashka" --source_id="babashka"
 
-export PATH=$install_dir/clojure/bin:$install_dir/babashka:$PATH
+export PATH=$JAVA_HOME/bin:$install_dir/clojure/bin:$install_dir/babashka:$PATH
 
 #=================================================
 # APP "BUILD" (DEPLOYING SOURCES, VENV, COMPILING ETC)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -52,7 +52,7 @@ then
 
 	ynh_setup_source --dest_dir="$install_dir/babashka" --source_id="babashka"
 
-	export PATH=$install_dir/clojure/bin:$install_dir/babashka:$PATH
+	export PATH=$JAVA_HOME/bin:$install_dir/clojure/bin:$install_dir/babashka:$PATH
 
 	ynh_script_progression --message="Upgrading source files..."
 


### PR DESCRIPTION
## Problem

- #6 

## Solution

- Explicitly set `PATH` so that Temurin is 'first' jdk impl found.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
