### PR TITLE
Fix sha256sum for 2.0.3

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -45,7 +45,7 @@ ram.runtime = "50M"
 
         [resources.sources.main]
         url = "https://github.com/penpot/penpot/archive/refs/tags/2.0.3.tar.gz"
-        sha256 = "8b0e05e238d1167b4d67f5a772834a98e0fd34d21c73b15a7b2407e1daa784ad"
+        sha256 = "5a5f73cf354d7b45a584eed589d779bbc52c051decb93365985e00e252b24dca"
         autoupdate.strategy = "latest_github_tag"
 
         [resources.sources.jdk]


### PR DESCRIPTION
## Problem

- Install fails due to sha256 mismatch.

## Solution

- Update with value for re-tagged 2.0.3

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
