### PR TITLE
Fix checksum for 2.1.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -45,7 +45,7 @@ ram.runtime = "50M"
 
         [resources.sources.main]
         url = "https://github.com/penpot/penpot/archive/refs/tags/2.1.0.tar.gz"
-        sha256 = "b3e0f9816e838e2ce12e29cbe13af5efa2756d4a8f66111adfce28bc6d4391b7"
+        sha256 = "47b816b92896c0786196385150fb4a8c7e5d3240516f7d48da1c998910f5c006"
         autoupdate.strategy = "latest_github_tag"
 
         [resources.sources.jdk]

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,7 +8,7 @@ name = "Penpot"
 description.en = "Design and prototyping platform"
 description.fr = "Plateforme de conception et de prototypage"
 
-version = "2.1.0~ynh1"
+version = "2.1.0~ynh2"
 
 maintainers = ["orhtej2"]
 


### PR DESCRIPTION
## Problem

- Error while trying to upgrade to version 2.1.0:
  ```
  YunoHost was able to download the asset 'main' (https://github.com/penpot/penpot/archive/refs/tags/2.1.0.tar.gz)
  for penpot, but the asset doesn't match the expected checksum. This could mean
  that some temporary network failure happened on your server, OR the asset was
  somehow changed by the upstream maintainer (or a malicious actor?) and YunoHost
  packagers need to investigate and perhaps update the app manifest to take this
  change into account.
  
      Expected sha256 checksum: b3e0f9816e838e2ce12e29cbe13af5efa2756d4a8f66111adfce28bc6d4391b7
      Downloaded sha256 checksum: 47b816b92896c0786196385150fb4a8c7e5d3240516f7d48da1c998910f5c006
      Downloaded file size: 56M
  ```

## Solution

- Matched the checksum to downloaded assets

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
