### PR TITLE
Increase startup timeout for penpot backend service

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -29,7 +29,7 @@ ynh_config_change_url_nginx
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot"
+ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot" --timeout=300
 
 ynh_systemctl --service=$app-exporter --action="start" --log_path="/var/log/$app/$app-exporter.log" --wait_until="redis connection established"
 

--- a/scripts/install
+++ b/scripts/install
@@ -219,7 +219,7 @@ ynh_config_add --template="exporter.env" --destination="$install_dir/exporter/.e
 ynh_script_progression "Starting $app's systemd service..."
 
 # Start a systemd service
-ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot"
+ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot" --timeout=300
 
 ynh_systemctl --service=$app-exporter --action="start" --log_path="/var/log/$app/$app-exporter.log" --wait_until="redis connection established"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -67,7 +67,7 @@ yunohost service add $app-exporter --log="/var/log/$app/$app-exporter.log"
 #=================================================
 ynh_script_progression "Reloading NGINX web server and $app's service..."
 
-ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot"
+ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot" --timeout=300
 
 ynh_systemctl --service=$app-exporter --action="start" --log_path="/var/log/$app/$app-exporter.log" --wait_until="redis connection established"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -206,7 +206,7 @@ ynh_config_add --template="exporter.env" --destination="$install_dir/exporter/.e
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot"
+ynh_systemctl --service=$app-backend --action="start" --log_path="/var/log/$app/$app-backend.log" --wait_until="welcome to penpot" --timeout=300
 
 ynh_systemctl --service=$app-exporter --action="start" --log_path="/var/log/$app/$app-exporter.log" --wait_until="redis connection established"
 


### PR DESCRIPTION
## Problem

- helpers v2.1 require service to start within timeout
- my VPS is trash

## Solution

- Increase timeout to let service to properly start

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
