### PR TITLE
Disable ImageMagick 7.x usage in run.template.sh

### DIFF
--- a/patches/main/main-003.patch
+++ b/patches/main/main-003.patch
@@ -1,0 +1,25 @@
+From 76505c1146b9a2a05e8c52cb29a3ed297f37049d Mon Sep 17 00:00:00 2001
+From: orhtej2 <2871798+orhtej2@users.noreply.github.com>
+Date: Sun, 7 Sep 2025 00:44:11 +0200
+Subject: [PATCH] Don't use ImageMagick 7.x
+
+---
+ backend/scripts/run.template.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/backend/scripts/run.template.sh b/backend/scripts/run.template.sh
+index 6124e44..16a8f77 100644
+--- a/backend/scripts/run.template.sh
++++ b/backend/scripts/run.template.sh
+@@ -18,7 +18,7 @@ if [ -f ./environ ]; then
+     source ./environ
+ fi
+ 
+-export JAVA_OPTS="-Dim4java.useV7=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dlog4j2.configurationFile=log4j2.xml -XX:-OmitStackTraceInFastThrow --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED --enable-preview $JVM_OPTS $JAVA_OPTS"
++export JAVA_OPTS="-Dim4java.useV7=false -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dlog4j2.configurationFile=log4j2.xml -XX:-OmitStackTraceInFastThrow --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED --enable-preview $JVM_OPTS $JAVA_OPTS"
+ 
+ ENTRYPOINT=${1:-app.main};
+ 
+-- 
+2.47.3
+


### PR DESCRIPTION
## Problem

- #145 

## Solution

- Use ImageMagick 6.x till we move to Trixie

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
